### PR TITLE
Fixup scripts to match test LLVMs and handle grammar changes, also add reproducible Nix environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+!shell.nix
 .DS_Store
+*.pyc
+llvm-pass/build/
+synthesisLogs/

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,78 @@
+with import <nixpkgs> {};
+
+let
+  unstable = import <nixos-unstable> {};
+in
+let
+  symfpu = stdenv.mkDerivation rec {
+    pname = "symfpu";
+    version = "8fbe139bf0071cbe0758d2f6690a546c69ff0053";
+    
+    src = fetchFromGitHub {
+      owner  = "martin-cs";
+      repo   = "symfpu";
+      rev    = version;
+      sha256 = "1jf5lkn67q136ppfacw3lsry369v7mdr1rhidzjpbz18jfy9zl9q";
+    };
+
+    installPhase = ''
+      mkdir -p $out
+      mkdir -p $out/symfpu
+      cp -r * $out/symfpu/
+    '';
+  };
+
+  cadicalCpp = unstable.cadical.overrideAttrs(super: {
+    installPhase = super.installPhase + ''
+      install -Dm0644 src/cadical.hpp "$dev/include/cadical.hpp"
+    '';
+  });
+in
+let
+  pythonPackages = python38Packages;
+  cvc5 = stdenv.mkDerivation rec {
+    pname = "cvc5";
+    version = "e607ce390cff26aa14862b2f9c1da727d14cdf68";
+
+    src = fetchFromGitHub {
+      owner  = "cvc5";
+      repo   = "cvc5";
+      rev    = version;
+      sha256 = "05nmgwh1s4xbwh0i5wn81i06p43y9n0xq34l52rv6dys3yb6qkac";
+    };
+
+    nativeBuildInputs = [ pkg-config cmake ];
+    buildInputs = [ gmp git python3.pkgs.toml gtest libantlr3c antlr3_4 boost jdk python3 ];
+
+    preConfigure = ''
+      patchShebangs ./src/
+    '';
+
+    cmakeFlags = [
+      "-DCMAKE_BUILD_TYPE=Production"
+      "-DCaDiCaL_INCLUDE_DIR=${cadicalCpp.dev}/include/"
+      "-DCaDiCaL_LIBRARIES=${cadicalCpp.lib}/lib/libcadical.a"
+      "-DCaDiCaL_FOUND=1"
+      "-DANTLR3_JAR=${antlr3_4}/lib/antlr/antlr-3.4-complete.jar"
+      "-DSymFPU_INCLUDE_DIR=${(symfpu)}"
+    ];
+  };
+in
+mkShell {
+  venvDir = "./.venv";
+  buildInputs = [
+    pythonPackages.python
+    pythonPackages.llvmlite
+    pythonPackages.pyparsing
+    pythonPackages.venvShellHook
+    (cvc5)
+    llvm_10
+    clang_10
+  ];
+
+  postShellHook = ''
+    pip install --upgrade pip
+  '';
+
+  hardeningDisable = [ "fortify" ];
+}

--- a/synthesis.py
+++ b/synthesis.py
@@ -129,7 +129,7 @@ def synthesize_new(targetLang, invAndPs, vars, preds, vc, cvcPath, basename):
 	toSMT(targetLang, "\n\n".join([str(i) for i in invAndPs]), vars, preds, vc, sygusFile, True)
 
 	logfile = synthDir + basename + '_logs.txt'
-	synthLogs = open(logfile, 'a')
+	synthLogs = open(logfile, 'w')
 	# Run synthesis subprocess
 	proc = subprocess.Popen([cvcPath, '--lang=sygus2', '--output=sygus', sygusFile],
 													stdout=synthLogs)  # ,stderr=subprocess.DEVNULL)

--- a/tests/compile
+++ b/tests/compile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # compiles benchmark and run switch converter and instruction namer on it
 
@@ -11,7 +11,12 @@ echo "output to:" $clang_out
 
 include_path="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
 
-clang -I $include_path -c -emit-llvm -S $file -o $clang_out
+if [[ $file == *.c ]]
+then
+  clang -O0 -I $include_path -c -emit-llvm -S $file -o $clang_out
+else
+  clang++ -O0 -I $include_path -c -emit-llvm -S $file -o $clang_out
+fi
 
 #opt -lowerswitch -instnamer -S $clang_out > tmp.ll
 opt -lowerinvoke --unreachableblockelim -instnamer -S $clang_out > tmp.ll

--- a/tests/compile-add-blocks
+++ b/tests/compile-add-blocks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # compiles benchmark and run switch converter and instruction namer on it
 
@@ -12,7 +12,12 @@ echo "output to:" $clang_out
 include_path="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
 
 #clang -g -I $include_path -c -emit-llvm -S $file -o $clang_out
-clang -I $include_path -c -emit-llvm -S $file -o $clang_out
+if [[ $file == *.c ]]
+then
+  clang -O0 -I $include_path -c -emit-llvm -S $file -o $clang_out
+else
+  clang++ -O0 -I $include_path -c -emit-llvm -S $file -o $clang_out
+fi
 
 #opt -lowerswitch -instnamer -S $clang_out > tmp.ll
 opt -load ../llvm-pass/build/addEmptyBlocks/libAddEmptyBlocksPass.so -addEmptyBlock -lowerinvoke --unreachableblockelim -instnamer -S $clang_out > tmp.ll

--- a/tests/compile-all
+++ b/tests/compile-all
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ls *.{c,cc} | xargs -n 1 ./compile


### PR DESCRIPTION
Updates the compilation scripts to use `-O0`, which produces the most similar LLVM to what's already checked in. Also adjusts `synthesize_new` to clear out the synthesis logs, since otherwise grammar changes are ignored. This PR also adds a [Nix](https://nixos.org) config that can be used to automatically configure all of the required dependencies in a reproducible manner.