### PR TITLE
Write DSL with FMA support, implement multiplication

### DIFF
--- a/ir.py
+++ b/ir.py
@@ -51,6 +51,7 @@ class Expr:
 
     Add = "+"
     Sub = "-"
+    Mul = "*"
 
     Eq = "="
     Lt = "<"
@@ -67,7 +68,7 @@ class Expr:
     Ite = "ite"
 
     Call = "call"
-    
+
     Assert = "assert"
     Constraint = "constraint"
     Axiom = "axiom"
@@ -142,15 +143,15 @@ class Expr:
     commonExprs = list(filter(lambda k: cnts[k] > 1 or k.kind == Expr.Kind.Choose, cnts.keys()))
     rewritten = Expr.replaceExprs(e.args[1], commonExprs)
     commonExprs = [Expr.replaceExprs(e, commonExprs, skipTop=True) for e in commonExprs]
-    
+
     args = " ".join("%s" % (a.name) for a in e.args[2:])
-    
+
     defs= "[rv (choose %s)]\n" % (rewritten if rewritten.kind == Expr.Kind.Var or rewritten.kind == Expr.Kind.Lit
                                                else "%s" % rewritten)
-    
+
     defs =  defs + "\n".join("%s %s)]" % ("[v%d (choose" % i, e) for i,e in enumerate(commonExprs))
-    
-   
+
+
     return "(define-grammar (%s_gram %s)\n %s\n)" % (e.args[0], args, defs)
 
   def __repr__(self):
@@ -175,14 +176,14 @@ class Expr:
             else:
               if (str(a)) in listFns.keys() and 'list_empty' in (str(a)):
                 callStr += '(' + listFns[str(a)] + ')' + " "
-              elif (str(a)) in listFns.keys(): 
+              elif (str(a)) in listFns.keys():
                  callStr += listFns[str(a)]  + " "
               else:
                 callStr += str(a) + " "
           callStr += '))'
           return callStr
         elif (self.args[0].startswith('list') and printMode == PrintMode.RosetteVC):
-          
+
           callStr = '(' + "%s"%(listFns[self.args[0]] if self.args[0] in listFns.keys() else self.args[0])  + " "
           for a in self.args[1:]:
             if isinstance(a, ValueRef) and a.name != "":
@@ -193,7 +194,7 @@ class Expr:
           return callStr
         else:
           if 'list_empty' in self.args:
-            return   " ".join([a.name if isinstance(a, ValueRef) and a.name != "" else str(a) for a in self.args]) 
+            return   " ".join([a.name if isinstance(a, ValueRef) and a.name != "" else str(a) for a in self.args])
           else:
             return '(' + " ".join([a.name if isinstance(a, ValueRef) and a.name != "" else str(a) for a in self.args]) + ')'
       else:
@@ -235,13 +236,14 @@ class Expr:
         elif k == Expr.Kind.Ite: value = "_if"
         elif k == Expr.Kind.Add: value = "_add"
         elif k == Expr.Kind.Sub: value = "_sub"
+        elif k == Expr.Kind.Mul: value = "_mul"
         elif k == Expr.Kind.Le: value = "_lte"
         elif k == Expr.Kind.Lt: value = "_lt"
         elif k == Expr.Kind.Ge: value = "_gte"
         elif k == Expr.Kind.Gt: value = "_gt"
 
         else: value = self.kind.value
-      
+
       if printMode == PrintMode.SMT or printMode == PrintMode.Rosette:
         return "(" + value + " " + " ".join([a.name if isinstance(a, ValueRef) and a.name != "" else str(a)
                                                      for a in self.args]) + ")"
@@ -288,6 +290,7 @@ def BoolLit(val): return Lit(val, Bool())
 
 def Add(*args): return Expr(Expr.Kind.Add, Int(), args)
 def Sub(*args): return Expr(Expr.Kind.Sub, Int(), args)
+def Mul(*args): return Expr(Expr.Kind.Mul, Int(), args)
 
 def Eq(e1, e2): return Expr(Expr.Kind.Eq, Bool(), [e1, e2])
 def Lt(e1, e2): return Expr(Expr.Kind.Lt, Bool(), [e1, e2])

--- a/synthesis.py
+++ b/synthesis.py
@@ -2,7 +2,7 @@ import subprocess
 import pyparsing as pp
 import os
 
-from ir import Expr, parseTypeRef, Constraint, MLInst_Assert, Call, FnDecl, Bool, Not, Add, Sub, Le, Lt, Ge, Gt, And, Or, Implies, Eq
+from ir import Expr, parseTypeRef, Constraint, MLInst_Assert, Call, FnDecl, Bool, Not, Add, Sub, Mul, Le, Lt, Ge, Gt, And, Or, Implies, Eq
 
 
 def flatten(L):
@@ -61,7 +61,7 @@ def generateCandidates(invAndPs, line, funName, returnType):
 	return candidates, candidatesExpr
 
 def toExpr(ast, funName, returnType):
-	expr_bi = {'=': Eq, '+': Add, '-': Sub, '<': Lt, '<=': Le, '>': Gt, '>=':  Ge,'and':  And, 'or':  Or, '=>':  Implies}
+	expr_bi = {'=': Eq, '+': Add, '-': Sub, '*': Mul, '<': Lt, '<=': Le, '>': Gt, '>=':  Ge,'and':  And, 'or':  Or, '=>':  Implies}
 	expr_uni = {'not': Not}
 	if ast[0] in expr_bi.keys():
 		return expr_bi[ast[0]](toExpr(ast[1], funName, returnType) , toExpr(ast[2], funName, returnType))
@@ -133,7 +133,7 @@ def synthesize_new(targetLang, invAndPs, vars, preds, vc, cvcPath, basename):
 	# Run synthesis subprocess
 	proc = subprocess.Popen([cvcPath, '--lang=sygus2', '--output=sygus', sygusFile],
 													stdout=synthLogs)  # ,stderr=subprocess.DEVNULL)
-	
+
 	funName, returnType = extractFuns(targetLang)
 	logfileVerif = open(logfile, "r")
 	while True:
@@ -144,7 +144,7 @@ def synthesize_new(targetLang, invAndPs, vars, preds, vc, cvcPath, basename):
 			candDef = "\n\n".join(str(d) for d in candidates)
 			smtFile = synthDir + basename + ".smt"
 			toSMT(targetLang, candDef, vars, preds, vc, smtFile, False)
-	
+
 			# run external verification subprocess
 			procVerify = subprocess.Popen([cvcPath, '--lang=smt', '--fmf-fun', '--tlimit=10000', smtFile],
 																		stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
@@ -153,9 +153,9 @@ def synthesize_new(targetLang, invAndPs, vars, preds, vc, cvcPath, basename):
 			if output.count('unsat') == 1:
 				print("UNSAT\n")
 				print("Verified PS and INV Candidates ", candDef)
-				#return verified invandPs as dict. {'inv0': expression, 'ps': expression} 
+				#return verified invandPs as dict. {'inv0': expression, 'ps': expression}
 				return candidatesExpr
-				
+
 			else:
 				print("CVC4 verification Result for Current Guess")
 				print("SAT\n")

--- a/tests/fma_dsl.c
+++ b/tests/fma_dsl.c
@@ -1,0 +1,10 @@
+int test(int base, int arg1, int base2, int arg2)
+{
+    int a = 0;
+
+    a = (base + base2) + arg1 * arg2;
+
+    a = a + a;
+
+    return a;
+}

--- a/tests/fma_dsl.ll
+++ b/tests/fma_dsl.ll
@@ -1,0 +1,44 @@
+; ModuleID = 'fma_dsl.ll'
+source_filename = "fma_dsl.c"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx11.0.0"
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @test(i32 %arg, i32 %arg1, i32 %arg2, i32 %arg3) #0 {
+bb:
+  %i = alloca i32, align 4
+  %i4 = alloca i32, align 4
+  %i5 = alloca i32, align 4
+  %i6 = alloca i32, align 4
+  %i7 = alloca i32, align 4
+  store i32 %arg, i32* %i, align 4
+  store i32 %arg1, i32* %i4, align 4
+  store i32 %arg2, i32* %i5, align 4
+  store i32 %arg3, i32* %i6, align 4
+  store i32 0, i32* %i7, align 4
+  %i8 = load i32, i32* %i, align 4
+  %i9 = load i32, i32* %i5, align 4
+  %i10 = add nsw i32 %i8, %i9
+  %i11 = load i32, i32* %i4, align 4
+  %i12 = load i32, i32* %i6, align 4
+  %i13 = mul nsw i32 %i11, %i12
+  %i14 = add nsw i32 %i10, %i13
+  store i32 %i14, i32* %i7, align 4
+  %i15 = load i32, i32* %i7, align 4
+  %i16 = load i32, i32* %i7, align 4
+  %i17 = add nsw i32 %i15, %i16
+  store i32 %i17, i32* %i7, align 4
+  %i18 = load i32, i32* %i7, align 4
+  ret i32 %i18
+}
+
+attributes #0 = { noinline nounwind optnone ssp uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="penryn" "target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+sse4.1,+ssse3,+x87" "tune-cpu"="generic" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"PIC Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 1}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"Homebrew clang version 13.0.0"}

--- a/tests/fma_dsl.loops
+++ b/tests/fma_dsl.loops
@@ -1,0 +1,1 @@
+Printing analysis 'Natural Loop Information' for function 'test':

--- a/tests/fma_dsl.py
+++ b/tests/fma_dsl.py
@@ -1,0 +1,104 @@
+import os
+import sys
+
+from analysis import CodeInfo, analyze
+from ir import (
+    Choose,
+    And,
+    Ge,
+    Eq,
+    Le,
+    Sub,
+    Synth,
+    Call,
+    Int,
+    IntLit,
+    Or,
+    FnDecl,
+    Var,
+    Add,
+    Mul,
+    Ite,
+)
+from synthesize_rosette import synthesize
+from rosette_translator import toRosette
+
+# # programmatically generated grammar
+
+# (synth-fun ps ( (tmp14 Int) (arg Int) ) Bool
+#  ((B Bool) (C Bool) (D Bool) (E Int) (F Int))
+#  ((B Bool ((or C D)))
+#  (C Bool ((>= F arg)))
+#  (D Bool ((= E (sum_n (- arg F)))))
+#  (E Int (tmp14))
+#  (F Int (1))))
+
+# (synth-fun inv0 ((tmp1 Int) (tmp2 Int) (arg Int) ) Bool
+#    ((B Bool) (C Bool) (D Bool) (E Int) (F Int))
+#    ((B Bool ((or C D)))
+#    (C Bool ((>= 1 arg) ))
+#    (D Bool ((and (>= E 1) (<= E arg) (= E (sum_n (- E F))))))
+#    (E Int (tmp1 tmp2))
+#    (F Int (1))))
+
+
+def grammar(ci: CodeInfo):
+    # print("Looking at", ci)
+    # print("read", ci.readVars)
+    # print("mod", ci.modifiedVars)
+    name = ci.name
+
+    if name.startswith("inv"):
+        raise RuntimeError("no invariants for loop-less grammar")
+    else:  # ps
+        inputVars = Choose(*ci.readVars, IntLit(0))
+        rv = ci.modifiedVars[0]
+        var_or_add = Add(inputVars, inputVars)
+        var_or_fma = Choose(*ci.readVars, Call("fma", Int(), var_or_add, var_or_add, var_or_add))
+        summary = Eq(rv, Add(var_or_fma, var_or_fma))
+        return Synth(name, summary, *ci.modifiedVars, *ci.readVars)
+
+
+def targetLang():
+    x = Var("x", Int())
+    y = Var("y", Int())
+    z = Var("z", Int())
+    sum_n = FnDecl(
+        "sum_n",
+        Int(),
+        Ite(
+            Ge(x, IntLit(1)), Add(x, Call("sum_n", Int(), Sub(x, IntLit(1)))), IntLit(0)
+        ),
+        x,
+    )
+    fma = FnDecl(
+        "fma",
+        Int(),
+        Add(x, Mul(y, z)),
+        x, y, z
+    )
+    return [sum_n, fma]
+
+
+if __name__ == "__main__":
+    filename = sys.argv[1]
+    basename = os.path.splitext(os.path.basename(filename))[0]
+
+    fnName = sys.argv[2]
+    loopsFile = sys.argv[3]
+    cvcPath = sys.argv[4]
+
+    (vars, invAndPs, preds, vc, loopAndPsInfo) = analyze(filename, fnName, loopsFile)
+
+    print("====== grammar")
+    invAndPs = [grammar(ci) for ci in loopAndPsInfo]
+
+    lang = targetLang()
+
+    # rosette synthesizer  + CVC verfication
+    print("====== synthesis")
+    candidates = synthesize(
+        basename, lang, vars, invAndPs, preds, vc, loopAndPsInfo, cvcPath
+    )
+    print("====== verified candidates")
+    print("\n\n".join(str(c) for c in candidates))

--- a/utils/utils.rkt
+++ b/utils/utils.rkt
@@ -10,6 +10,7 @@
 (struct _if (arg1 arg2 arg3) #:transparent)
 (struct _add (arg1 arg2) #:transparent)
 (struct _sub (arg1 arg2) #:transparent)
+(struct _mul (arg1 arg2) #:transparent)
 (struct _list_append (arg1 arg2) #:transparent)
 (struct _list_concat (arg1 arg2) #:transparent)
 (struct _list_tail (arg1 arg2) #:transparent)
@@ -30,12 +31,13 @@
     [(_if a1 a2 a3) (if (interpret a1 env) (interpret a2 env) (interpret a3 env))]
     [(_add a1 a2) (+ (interpret a1 env) (interpret a2 env))]
     [(_sub a1 a2) (- (interpret a1 env) (interpret a2 env))]
+    [(_mul a1 a2) (* (interpret a1 env) (interpret a2 env))]
     [(_list_append a1 a2)  (append (interpret a1 env) (interpret a2 env))]
     [(_list_concat a1 a2)  (append (interpret a1 env) (interpret a2 env))]
     [(_list_tail a1 a2)  (list-tail-noerr (interpret a1 env) (interpret a2 env))]
     [(_list_eq a1 a2)  (equal? (interpret a1 env) (interpret a2 env))] ; not eq?
     [(_list_take a1 a2)  (take (interpret a1 env) (interpret a2 env)) ]
-    [(_list_length a1)  (length (interpret a1 env))]    
+    [(_list_length a1)  (length (interpret a1 env))]
     [(loc i) (vector-ref env i)]
     [_ (interpret2 e env)]))
 

--- a/vc.py
+++ b/vc.py
@@ -7,7 +7,7 @@ from llvmlite.ir import Argument
 
 import models
 from ir import Expr, Type, parseTypeRef, Var, Call, Lit, Bool, Int, List, Eq, Lt, Le, Not, Or, And, Implies, Synth, Ite, \
-  Add, Sub, BoolLit
+  Add, Sub, Mul, BoolLit
 
 
 class State:
@@ -207,11 +207,12 @@ class VC:
         # store either a reg or a literal
         s.mem[ops[1]] = VC.parseOperand(ops[0], s.regs)
 
-      elif opcode == "add" or opcode == "sub":
+      elif opcode in ("add", "sub", "mul"):
         op1 = VC.parseOperand(ops[0], s.regs)
         op2 = VC.parseOperand(ops[1], s.regs)
         if opcode == "add": s.regs[i] = Add(op1, op2)
         elif opcode == "sub": s.regs[i] = Sub(op1, op2)
+        elif opcode == "mul": s.regs[i] = Mul(op1, op2)
 
       elif opcode == "icmp":
         cond = re.match("\S+ = icmp (\w+) \S+ \S+ \S+", str(i).strip()).group(1)


### PR DESCRIPTION
The cases are added under `tests` with basename `fma_dsl`.

### Sample case:
```c
int test(int base, int arg1, int base2, int arg2)
{
    int a = 0;

    a = (base + base2) + arg1 * arg2;

    a = a + a;

    return a;
}
```

### Output:
#### Summary
```scheme
(_eq (loc 0) (_add (_fma (_add (loc 1) (loc 3)) (_add 0 (loc 4)) (_add 0 (loc 2))) (_fma (_add (loc 3) (loc 1)) (_add (loc 4) 0) (_add (loc 2) 0))))
```

#### Verified Candidate
```scheme
(define-fun-rec ps ((i18 Int) (arg Int) (arg1 Int) (arg2 Int) (arg3 Int)) Bool
(= i18 (+ (fma (+ arg arg2) (+ 0 arg3) (+ 0 arg1)) (fma (+ arg2 arg) (+ arg3 0) (+ arg1 0)))))
```

which is exactly correct.

---

### Explanation:

```math
f(b, a1, b2, a2) = 2 * ((b + b2) + a1 * a2)
= (b + b2) + (b + b2) * (2 * a1) * a2
```

which is equivalent to the program output of:
 
```
(_add
    (_fma
        (_add (loc 1) (loc 3))
        (_add (loc 2) (loc 2))
        (_add 0 (loc 4))
    ) ; (base + base2) + (2 * arg1) * (arg2)
    
    (_fma
        (_add (loc 1) (loc 3))
        (_add 0 0)
        (_add (loc 3) (loc 3))
    ) ; (base + base2)
)

; 2 * ((base + base2) + (arg1 * arg2))
; = 2 (base1 + base2) + 2 (arg1 * arg2)
; = (base1 + base2) + (base1 + base2) * (2 * arg1) * arg2
```