### PR TITLE
Shift back to standard llvmlite

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,13 +27,8 @@
           (poetry2nix.mkPoetryEnv {
             python = python38;
             projectDir = ./.;
-            preferWheels = true;
 
             overrides = poetry2nix.overrides.withDefaults (_: poetrySuper: {
-              llvmlite = poetrySuper.llvmlite.overridePythonAttrs(super: {
-                src = llvmlite-patched;
-              });
-
               autoflake = poetrySuper.autoflake.overrideAttrs(_: super: {
                 nativeBuildInputs = super.nativeBuildInputs ++ [ poetrySuper.hatchling ];
               });

--- a/metalift/analysis.py
+++ b/metalift/analysis.py
@@ -23,6 +23,7 @@ from metalift.ir import (
 from metalift.vc import Block, VC
 from llvmlite.binding import ValueRef
 from typing import (
+    Any,
     Callable,
     Dict,
     Iterable,
@@ -38,8 +39,8 @@ from typing import (
 orig_value_ref_operands = ValueRef.operands
 
 
-@property
-def new_value_ref_operands(self):
+@property  # type: ignore
+def new_value_ref_operands(self: ValueRef) -> Any:
     if hasattr(self, "my_operands") and self.my_operands:
         return self.my_operands
     else:

--- a/metalift/analysis.py
+++ b/metalift/analysis.py
@@ -36,6 +36,8 @@ from typing import (
 )
 
 orig_value_ref_operands = ValueRef.operands
+
+
 @property
 def new_value_ref_operands(self):
     if hasattr(self, "my_operands") and self.my_operands:
@@ -43,7 +45,9 @@ def new_value_ref_operands(self):
     else:
         return orig_value_ref_operands.__get__(self)
 
+
 setattr(ValueRef, "operands", new_value_ref_operands)
+
 
 def setupBlocks(blks: Iterable[ValueRef]) -> Dict[str, Block]:
     bbs = dict((b.name, Block(b.name, list(b.instructions))) for b in blks)
@@ -367,15 +371,23 @@ def parseObjectFuncs(blocksMap: Dict[str, Block]) -> None:
                     fieldName = r.group(3)
                     if op == "set":
                         # newInst = MLInst_Call("setField", i.type, Lit(fieldName, String()), ops[0], ops[1])
-                        setattr(i, "my_operands", [
-                            Lit(fieldName, String()),
-                            ops[0],
-                            ops[1],
-                            "setField",
-                        ])
+                        setattr(
+                            i,
+                            "my_operands",
+                            [
+                                Lit(fieldName, String()),
+                                ops[0],
+                                ops[1],
+                                "setField",
+                            ],
+                        )
                     else:
                         # i.operands = ["getField", i.type, Lit(fieldName, String()), ops[0], "getField"]
-                        setattr(i, "my_operands", [Lit(fieldName, String()), ops[0], "getField"])
+                        setattr(
+                            i,
+                            "my_operands",
+                            [Lit(fieldName, String()), ops[0], "getField"],
+                        )
                         # print("inst: %s" % i)
 
 

--- a/metalift/analysis.py
+++ b/metalift/analysis.py
@@ -35,6 +35,15 @@ from typing import (
     cast,
 )
 
+orig_value_ref_operands = ValueRef.operands
+@property
+def new_value_ref_operands(self):
+    if hasattr(self, "my_operands") and self.my_operands:
+        return self.my_operands
+    else:
+        return orig_value_ref_operands.__get__(self)
+
+setattr(ValueRef, "operands", new_value_ref_operands)
 
 def setupBlocks(blks: Iterable[ValueRef]) -> Dict[str, Block]:
     bbs = dict((b.name, Block(b.name, list(b.instructions))) for b in blks)
@@ -358,15 +367,15 @@ def parseObjectFuncs(blocksMap: Dict[str, Block]) -> None:
                     fieldName = r.group(3)
                     if op == "set":
                         # newInst = MLInst_Call("setField", i.type, Lit(fieldName, String()), ops[0], ops[1])
-                        i.operands = [
+                        setattr(i, "my_operands", [
                             Lit(fieldName, String()),
                             ops[0],
                             ops[1],
                             "setField",
-                        ]
+                        ])
                     else:
                         # i.operands = ["getField", i.type, Lit(fieldName, String()), ops[0], "getField"]
-                        i.operands = [Lit(fieldName, String()), ops[0], "getField"]
+                        setattr(i, "my_operands", [Lit(fieldName, String()), ops[0], "getField"])
                         # print("inst: %s" % i)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,15 +86,12 @@ python-versions = "*"
 
 [[package]]
 name = "llvmlite"
-version = "0+unknown"
+version = "0.39.1"
 description = "lightweight wrapper around basic LLVM functionality"
 category = "main"
 optional = false
-python-versions = ">=3.7,<3.11"
+python-versions = ">=3.7"
 
-[package.source]
-type = "url"
-url = "https://github.com/metalift/llvmlite/archive/c418eb18a78f49d9a059c50bd992f732432b9fe5.zip"
 [[package]]
 name = "monotable"
 version = "3.1.0"
@@ -283,7 +280,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "81136132768954330393fc21cbc9385f0aecc840d2299bfc713aaf0d3d8e3a31"
+content-hash = "576d1f7efad8dce09eac37abb2cbab2c1d299f5ef89998ec72505a4099197763"
 
 [metadata.files]
 attrs = [
@@ -335,7 +332,36 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
-llvmlite = []
+llvmlite = [
+    {file = "llvmlite-0.39.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6717c7a6e93c9d2c3d07c07113ec80ae24af45cde536b34363d4bcd9188091d9"},
+    {file = "llvmlite-0.39.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ddab526c5a2c4ccb8c9ec4821fcea7606933dc53f510e2a6eebb45a418d3488a"},
+    {file = "llvmlite-0.39.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3f331a323d0f0ada6b10d60182ef06c20a2f01be21699999d204c5750ffd0b4"},
+    {file = "llvmlite-0.39.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2c00ff204afa721b0bb9835b5bf1ba7fba210eefcec5552a9e05a63219ba0dc"},
+    {file = "llvmlite-0.39.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16f56eb1eec3cda3a5c526bc3f63594fc24e0c8d219375afeb336f289764c6c7"},
+    {file = "llvmlite-0.39.1-cp310-cp310-win32.whl", hash = "sha256:d0bfd18c324549c0fec2c5dc610fd024689de6f27c6cc67e4e24a07541d6e49b"},
+    {file = "llvmlite-0.39.1-cp310-cp310-win_amd64.whl", hash = "sha256:7ebf1eb9badc2a397d4f6a6c8717447c81ac011db00064a00408bc83c923c0e4"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6546bed4e02a1c3d53a22a0bced254b3b6894693318b16c16c8e43e29d6befb6"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1578f5000fdce513712e99543c50e93758a954297575610f48cb1fd71b27c08a"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3803f11ad5f6f6c3d2b545a303d68d9fabb1d50e06a8d6418e6fcd2d0df00959"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50aea09a2b933dab7c9df92361b1844ad3145bfb8dd2deb9cd8b8917d59306fb"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-win32.whl", hash = "sha256:b1a0bbdb274fb683f993198775b957d29a6f07b45d184c571ef2a721ce4388cf"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e172c73fccf7d6db4bd6f7de963dedded900d1a5c6778733241d878ba613980e"},
+    {file = "llvmlite-0.39.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e31f4b799d530255aaf0566e3da2df5bfc35d3cd9d6d5a3dcc251663656c27b1"},
+    {file = "llvmlite-0.39.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:62c0ea22e0b9dffb020601bb65cb11dd967a095a488be73f07d8867f4e327ca5"},
+    {file = "llvmlite-0.39.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ffc84ade195abd4abcf0bd3b827b9140ae9ef90999429b9ea84d5df69c9058c"},
+    {file = "llvmlite-0.39.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0f158e4708dda6367d21cf15afc58de4ebce979c7a1aa2f6b977aae737e2a54"},
+    {file = "llvmlite-0.39.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22d36591cd5d02038912321d9ab8e4668e53ae2211da5523f454e992b5e13c36"},
+    {file = "llvmlite-0.39.1-cp38-cp38-win32.whl", hash = "sha256:4c6ebace910410daf0bebda09c1859504fc2f33d122e9a971c4c349c89cca630"},
+    {file = "llvmlite-0.39.1-cp38-cp38-win_amd64.whl", hash = "sha256:fb62fc7016b592435d3e3a8f680e3ea8897c3c9e62e6e6cc58011e7a4801439e"},
+    {file = "llvmlite-0.39.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa9b26939ae553bf30a9f5c4c754db0fb2d2677327f2511e674aa2f5df941789"},
+    {file = "llvmlite-0.39.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e4f212c018db951da3e1dc25c2651abc688221934739721f2dad5ff1dd5f90e7"},
+    {file = "llvmlite-0.39.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39dc2160aed36e989610fc403487f11b8764b6650017ff367e45384dff88ffbf"},
+    {file = "llvmlite-0.39.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1ec3d70b3e507515936e475d9811305f52d049281eaa6c8273448a61c9b5b7e2"},
+    {file = "llvmlite-0.39.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60f8dd1e76f47b3dbdee4b38d9189f3e020d22a173c00f930b52131001d801f9"},
+    {file = "llvmlite-0.39.1-cp39-cp39-win32.whl", hash = "sha256:03aee0ccd81735696474dc4f8b6be60774892a2929d6c05d093d17392c237f32"},
+    {file = "llvmlite-0.39.1-cp39-cp39-win_amd64.whl", hash = "sha256:3fc14e757bc07a919221f0cbaacb512704ce5774d7fcada793f1996d6bc75f2a"},
+    {file = "llvmlite-0.39.1.tar.gz", hash = "sha256:b43abd7c82e805261c425d50335be9a6c4f84264e34d6d6e475207300005d572"},
+]
 monotable = [
     {file = "monotable-3.1.0-py3-none-any.whl", hash = "sha256:2bdd9b245f894406642899ab82032cc4ad0d890b2972fd0ecdb52c1b1a6c9f21"},
     {file = "monotable-3.1.0.tar.gz", hash = "sha256:68fafb1df6b1f0aff391d558921215d808fcaca076b2960e44e3fd0657e243d4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = []
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 pyparsing = "^3.0.8"
-llvmlite = { url = "https://github.com/metalift/llvmlite/archive/c418eb18a78f49d9a059c50bd992f732432b9fe5.zip" }
+llvmlite = "^0.39.1"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.950"


### PR DESCRIPTION
Git dependencies cause a lot of trouble for downstream dependents, this brings us closer to being able to publish a standard package.