### PR TITLE
Correctly handle numeric negation when parsing expressions

### DIFF
--- a/metalift/synthesize_cvc5.py
+++ b/metalift/synthesize_cvc5.py
@@ -104,10 +104,16 @@ def toExpr(
     expr_uni = {"not": Not}
     if isinstance(ast, list):
         if ast[0] in expr_bi.keys():
-            return expr_bi[ast[0]](
-                toExpr(ast[1], funName, returnType, varType, letVars),
-                toExpr(ast[2], funName, returnType, varType, letVars),
-            )
+            if len(ast) >= 3:
+                return expr_bi[ast[0]](
+                    toExpr(ast[1], funName, returnType, varType, letVars),
+                    toExpr(ast[2], funName, returnType, varType, letVars),
+                )
+            else:
+                return expr_bi[ast[0]](
+                    toExpr(0, funName, returnType, varType, letVars),
+                    toExpr(ast[1], funName, returnType, varType, letVars),
+                )
         elif ast[0] in expr_uni.keys():
             return expr_uni[ast[0]](
                 toExpr(ast[1], funName, returnType, varType, letVars)

--- a/metalift/synthesize_cvc5.py
+++ b/metalift/synthesize_cvc5.py
@@ -111,7 +111,7 @@ def toExpr(
                 )
             elif ast[0] == "-":
                 return expr_bi[ast[0]](
-                    toExpr("0", funName, returnType, varType, letVars),
+                    toExpr("0", funName, returnType, varType, letVars), # type: ignore
                     toExpr(ast[1], funName, returnType, varType, letVars),
                 )
             else:

--- a/metalift/synthesize_cvc5.py
+++ b/metalift/synthesize_cvc5.py
@@ -111,7 +111,7 @@ def toExpr(
                 )
             elif ast[0] == "-":
                 return expr_bi[ast[0]](
-                    toExpr("0", funName, returnType, varType, letVars), # type: ignore
+                    toExpr("0", funName, returnType, varType, letVars),  # type: ignore
                     toExpr(ast[1], funName, returnType, varType, letVars),
                 )
             else:

--- a/metalift/synthesize_cvc5.py
+++ b/metalift/synthesize_cvc5.py
@@ -104,12 +104,12 @@ def toExpr(
     expr_uni = {"not": Not}
     if isinstance(ast, list):
         if ast[0] in expr_bi.keys():
-            if len(ast) >= 3:
+            if len(ast) == 3:
                 return expr_bi[ast[0]](
                     toExpr(ast[1], funName, returnType, varType, letVars),
                     toExpr(ast[2], funName, returnType, varType, letVars),
                 )
-            elif ast[0] == "-":
+            elif len(ast) == 2 and ast[0] == "-":
                 return expr_bi[ast[0]](
                     toExpr("0", funName, returnType, varType, letVars),  # type: ignore
                     toExpr(ast[1], funName, returnType, varType, letVars),

--- a/metalift/synthesize_cvc5.py
+++ b/metalift/synthesize_cvc5.py
@@ -111,7 +111,7 @@ def toExpr(
                 )
             elif len(ast) == 2 and ast[0] == "-":
                 return expr_bi[ast[0]](
-                    toExpr("0", funName, returnType, varType, letVars),  # type: ignore
+                    IntLit(0),
                     toExpr(ast[1], funName, returnType, varType, letVars),
                 )
             else:

--- a/metalift/synthesize_cvc5.py
+++ b/metalift/synthesize_cvc5.py
@@ -109,11 +109,13 @@ def toExpr(
                     toExpr(ast[1], funName, returnType, varType, letVars),
                     toExpr(ast[2], funName, returnType, varType, letVars),
                 )
-            else:
+            elif ast[0] == "-":
                 return expr_bi[ast[0]](
-                    toExpr(0, funName, returnType, varType, letVars),
+                    toExpr("0", funName, returnType, varType, letVars),
                     toExpr(ast[1], funName, returnType, varType, letVars),
                 )
+            else:
+                raise ValueError("Unexpected number of arguments", ast)
         elif ast[0] in expr_uni.keys():
             return expr_uni[ast[0]](
                 toExpr(ast[1], funName, returnType, varType, letVars)


### PR DESCRIPTION
A `(- 2)` can be considered the negation of a positive integer `2`, but the current parsing would look for and create a `Sub` operator. This is OK, but `Sub` requires two arguments and we need to manually supply it with a `0` if the original expression does not contain two arguments.