### PR TITLE
minor bug fixes in VC and IR

### DIFF
--- a/metalift/analysis.py
+++ b/metalift/analysis.py
@@ -352,7 +352,7 @@ def parseGlobals(
 
     if log:
         print("globals:")
-        for (k, v) in globalVars.items():
+        for k, v in globalVars.items():
             print("%s -> %s" % (k, v))
     return globalVars
 

--- a/metalift/analysis.py
+++ b/metalift/analysis.py
@@ -237,7 +237,8 @@ def processLoops(
         for i in blk.instructions:
             opcode = i.opcode
             ops = list(i.operands)
-            if opcode == "store":
+            # prevent duplicate havocs in nested loops
+            if opcode == "store" and ops[1] not in havocs:
                 havocs.append(ops[1])
 
     global invNum

--- a/metalift/ir.py
+++ b/metalift/ir.py
@@ -1791,7 +1791,9 @@ def parseTypeRef(t: Union[Type, TypeRef]) -> Type:
     elif tyStr == "i1" or tyStr == "Bool":
         return Bool()
     elif (
-        tyStr.startswith("%struct.list*") or tyStr == "%struct.list**" or tyStr == "(MLList Int)"
+        tyStr.startswith("%struct.list*")
+        or tyStr == "%struct.list**"
+        or tyStr == "(MLList Int)"
     ):
         return Type("MLList", Int())
     elif tyStr.startswith("%struct.set"):

--- a/metalift/ir.py
+++ b/metalift/ir.py
@@ -251,6 +251,8 @@ class Expr:
                     return Or(*newArgs)
                 elif isinstance(e, Not):
                     return Not(*newArgs)
+                elif isinstance(e, Implies):
+                    return Implies(*newArgs)
                 elif isinstance(e, Add):
                     return Add(*newArgs)
                 elif isinstance(e, Sub):
@@ -1789,7 +1791,7 @@ def parseTypeRef(t: Union[Type, TypeRef]) -> Type:
     elif tyStr == "i1" or tyStr == "Bool":
         return Bool()
     elif (
-        tyStr == "%struct.list*" or tyStr == "%struct.list**" or tyStr == "(MLList Int)"
+        tyStr.startswith("%struct.list*") or tyStr == "%struct.list**" or tyStr == "(MLList Int)"
     ):
         return Type("MLList", Int())
     elif tyStr.startswith("%struct.set"):

--- a/metalift/rosette_translator.py
+++ b/metalift/rosette_translator.py
@@ -6,6 +6,7 @@ from metalift.ir import Expr, FnDeclRecursive, FnDecl, Var
 from llvmlite.binding import ValueRef
 from typing import Any, Dict, List, Sequence, Set, Tuple, Union, Optional
 
+
 # TODO: mypy 0.95 says parseString returns Any instead of ParseResults despite what pyparse's doc says
 def generateAST(expr: str) -> Union[List[Any], pp.ParseResults]:
     s_expr = pp.nestedExpr(opener="(", closer=")")
@@ -92,7 +93,6 @@ def generateSynth(
     vars: List[str],
     invariant_guesses: List[Any],
 ) -> str:
-
     listvars = "(list " + " ".join(vars) + ")"
     if invariant_guesses:
         blocking_constraints = []
@@ -112,7 +112,6 @@ def generateSynth(
 
 
 def generateInvPs(loopAndPsInfo: Sequence[Union[CodeInfo, Expr]]) -> str:
-
     decls = ""
     for i in loopAndPsInfo:
         all_args = (
@@ -145,7 +144,6 @@ def toRosette(
     writeChoicesTo: Optional[Dict[str, Dict[str, Expr]]] = None,
     verifyMode: bool = False,
 ) -> None:
-
     f = open(filename, "w")
     print(
         "#lang rosette\n"

--- a/metalift/synthesize_rosette.py
+++ b/metalift/synthesize_rosette.py
@@ -53,7 +53,6 @@ def toExpr(
     choices: Dict[str, Expr],
     typeHint: typing.Optional[Type] = None,
 ) -> Expr:
-
     expr_bi: Dict[str, Callable[..., Expr]] = {
         "equal?": Eq,
         "+": Add,

--- a/metalift/vc.py
+++ b/metalift/vc.py
@@ -100,7 +100,6 @@ class VC:
         gvars: Dict[str, str],
         uninterpFuncs: typing.List[str] = [],
     ) -> typing.Tuple[typing.Set[Var], typing.List[Synth], typing.List[Expr], Expr]:
-
         initBlock = blocksMap[firstBlockName]
         initBlock.state.assumes.append(BoolLit(True))
         initBlock.state.gvars = gvars
@@ -377,7 +376,7 @@ class VC:
                 if cond == "eq":
                     r: Expr = Eq(op2, op1)
                 elif cond == "ne":
-                    r : Expr = Not(Eq(op2, op1))
+                    r = Not(Eq(op2, op1))
                 elif cond == "sgt":
                     r = Lt(op2, op1)
                 elif cond == "sle":

--- a/metalift/vc.py
+++ b/metalift/vc.py
@@ -376,6 +376,8 @@ class VC:
 
                 if cond == "eq":
                     r: Expr = Eq(op2, op1)
+                elif cond == "ne":
+                    r : Expr = Not(Eq(op2, op1))
                 elif cond == "sgt":
                     r = Lt(op2, op1)
                 elif cond == "sle":


### PR DESCRIPTION
Minor fixes for bugs I found recently
- Adding not equal opcode in the VC generator
- Invariant calls for nested loop has duplicate variables which breaks rosette 
- check for implies operator was missing in the replaceExpr function in vc.py