### PR TITLE
fix small bugs on website

### DIFF
--- a/website/docs/tutorial/simple-transpiler.md
+++ b/website/docs/tutorial/simple-transpiler.md
@@ -98,7 +98,7 @@ int test(int base, int arg1, int base2, int arg2) {
 }
 ```
 
-We do this using the [script provided by Metalift](https://github.com/metalift/metalift/blob/main/tests/compile-add-blocks). The script generates both the LLVM bitcode (.ll) file, along with a file containing loop information (.loops, which is empty since our input code does not contain any loops).
+We do this using the [script provided by Metalift](https://github.com/starptr/metalift/blob/oscar/main/tests/compile-add-blocks). The script generates both the LLVM bitcode (.ll) file, along with a file containing loop information (.loops, which is empty since our input code does not contain any loops).
 
 We pass these file names to Metalift's `analyze` function, which returns a number of results. The most important is the last one, which contains [information about the code to be transpiled](https://github.com/metalift/metalift/blob/main/metalift/analysis.py#L185). The code info is then used to generate our grammar as described above. 
 

--- a/website/docs/tutorial/transpiler-for-hardware.md
+++ b/website/docs/tutorial/transpiler-for-hardware.md
@@ -137,7 +137,7 @@ The ```CodeInfo``` object consists of all the variables that are modified in the
 
 
 ## Transpiler flow
-Once the target operators semantics and the search space description is defined, we can build the transpiler now. First, we need to compiler the source code to LLVM bytecode using the [script provided by Metalift].(https://github.com/starptr/metalift/blob/oscar/main/tests/compile-add-blocks). The script generates both the LLVM bitcode (.ll) file by calling the Clang compiler, along with a file containing loop information.
+Once the target operators semantics and the search space description is defined, we can build the transpiler now. First, we need to compiler the source code to LLVM bytecode using the [script provided by Metalift](https://github.com/starptr/metalift/blob/oscar/main/tests/compile-add-blocks). The script generates both the LLVM bitcode (.ll) file by calling the Clang compiler, along with a file containing loop information.
 
 <!--phmdoctest-mark.skip-->
 ```python


### PR DESCRIPTION
The script provided in the [FMA tutorial](https://metalift.pages.dev/docs/tutorial/simple-transpiler#transpiler-flow) is outdated and no longer valid. I have updated the script to ensure it works correctly with the current setup.

In the [Accelerator tutorial](https://metalift.pages.dev/docs/tutorial/transpiler-for-hardware#transpiler-flow), there was a minor bug in the markdown syntax. I have fixed this issue to ensure proper rendering of the documentation.